### PR TITLE
IPv6 attributes support

### DIFF
--- a/remote/lib/fingerbank/Base/Schema/DHCP6_Enterprise.pm
+++ b/remote/lib/fingerbank/Base/Schema/DHCP6_Enterprise.pm
@@ -1,0 +1,21 @@
+package fingerbank::Base::Schema::DHCP6_Enterprise;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::Schema';
+
+__PACKAGE__->table('dhcp6_enterprise');
+
+__PACKAGE__->add_columns(
+   "id",
+   "value",
+   "created_at",
+   "updated_at",
+);
+
+__PACKAGE__->set_primary_key('id');
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/remote/lib/fingerbank/Base/Schema/DHCP6_Fingerprint.pm
+++ b/remote/lib/fingerbank/Base/Schema/DHCP6_Fingerprint.pm
@@ -1,0 +1,21 @@
+package fingerbank::Base::Schema::DHCP6_Fingerprint;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::Schema';
+
+__PACKAGE__->table('dhcp6_fingerprint');
+
+__PACKAGE__->add_columns(
+   "id",
+   "value",
+   "created_at",
+   "updated_at",
+);
+
+__PACKAGE__->set_primary_key('id');
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/remote/lib/fingerbank/Model/DHCP6_Enterprise.pm
+++ b/remote/lib/fingerbank/Model/DHCP6_Enterprise.pm
@@ -1,0 +1,47 @@
+package fingerbank::Model::DHCP6_Enterprise;
+
+=head1 NAME
+
+fingerbank::Model::DHCP6_Enterprise
+
+=head1 DESCRIPTION
+
+Handling 'DHCP6_Enterprise' related stuff
+
+=cut
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::CRUD';
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/remote/lib/fingerbank/Model/DHCP6_Fingerprint.pm
+++ b/remote/lib/fingerbank/Model/DHCP6_Fingerprint.pm
@@ -1,0 +1,47 @@
+package fingerbank::Model::DHCP6_Fingerprint;
+
+=head1 NAME
+
+fingerbank::Model::DHCP6_Fingerprint
+
+=head1 DESCRIPTION
+
+Handling 'DHCP6_Fingerprint' related stuff
+
+=cut
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::CRUD';
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/remote/lib/fingerbank/Schema/Local/DHCP6_Enterprise.pm
+++ b/remote/lib/fingerbank/Schema/Local/DHCP6_Enterprise.pm
@@ -1,0 +1,10 @@
+package fingerbank::Schema::Local::DHCP6_Enterprise;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::Schema::DHCP6_Enterprise';
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/remote/lib/fingerbank/Schema/Local/DHCP6_Fingerprint.pm
+++ b/remote/lib/fingerbank/Schema/Local/DHCP6_Fingerprint.pm
@@ -1,0 +1,10 @@
+package fingerbank::Schema::Local::DHCP6_Fingerprint;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::Schema::DHCP6_Fingerprint';
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/remote/lib/fingerbank/Schema/Upstream/DHCP6_Enterprise.pm
+++ b/remote/lib/fingerbank/Schema/Upstream/DHCP6_Enterprise.pm
@@ -1,0 +1,10 @@
+package fingerbank::Schema::Upstream::DHCP6_Enterprise;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::Schema::DHCP6_Enterprise';
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/remote/lib/fingerbank/Schema/Upstream/DHCP6_Fingerprint.pm
+++ b/remote/lib/fingerbank/Schema/Upstream/DHCP6_Fingerprint.pm
@@ -1,0 +1,10 @@
+package fingerbank::Schema::Upstream::DHCP6_Fingerprint;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::Schema::DHCP6_Fingerprint';
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/upstream/Gemfile
+++ b/upstream/Gemfile
@@ -40,6 +40,7 @@ gem 'browser'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
+gem 'jquery-turbolinks'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/upstream/Gemfile.lock
+++ b/upstream/Gemfile.lock
@@ -56,6 +56,9 @@ GEM
     jquery-rails (3.1.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.2)
     jwt (1.0.0)
     libv8 (3.16.14.3)
@@ -168,6 +171,7 @@ DEPENDENCIES
   iconv
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-turbolinks
   mysql2
   omniauth-github
   rails (= 4.1.9)

--- a/upstream/app/assets/javascripts/application.js
+++ b/upstream/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery.turbolinks
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .

--- a/upstream/app/assets/javascripts/application.js
+++ b/upstream/app/assets/javascripts/application.js
@@ -11,8 +11,6 @@
 // about supported directives.
 //
 //= require jquery
-//= require bootstrap-sprockets
-//= require bootstrap
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .

--- a/upstream/app/assets/javascripts/combinations.js
+++ b/upstream/app/assets/javascripts/combinations.js
@@ -1,0 +1,7 @@
+
+$("document").ready(function(){
+  $('tr.combination').click(function(){
+    var self = $(this);
+    $('#show_'+self.data('combination-id')).click();
+  });
+});

--- a/upstream/app/assets/stylesheets/application.scss
+++ b/upstream/app/assets/stylesheets/application.scss
@@ -10,7 +10,6 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require bootstrap
  *= require_tree .
  *= require_self
  */

--- a/upstream/app/assets/stylesheets/combinations.css.scss
+++ b/upstream/app/assets/stylesheets/combinations.css.scss
@@ -6,3 +6,12 @@ div.search{
   padding:0 1em; 
   display:inline-block;
 }
+
+span.splitter{
+  display:block;
+  border-top:1px ridge #428bca;
+}
+
+td.device_info{
+  padding:0.3em;
+}

--- a/upstream/app/assets/stylesheets/combinations.css.scss
+++ b/upstream/app/assets/stylesheets/combinations.css.scss
@@ -2,6 +2,19 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
+div#combination_details {
+  .modal-footer {
+    .options {
+      float:left;
+      display:inline-block;
+    }
+  }
+}
+
+tr.combination {
+  cursor: pointer;
+}
+
 div.search{
   padding:0 1em; 
   display:inline-block;

--- a/upstream/app/assets/stylesheets/global.css.scss
+++ b/upstream/app/assets/stylesheets/global.css.scss
@@ -53,7 +53,7 @@ td{
 }
 
 td.shortened {
-  max-width:200px;
+  max-width:300px;
   overflow:hidden;
   text-overflow:ellipsis;
 }

--- a/upstream/app/assets/stylesheets/global.css.scss
+++ b/upstream/app/assets/stylesheets/global.css.scss
@@ -1,6 +1,10 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 
+.table-striped > tbody > tr:nth-child(2n+1) > td, .table-striped > tbody > tr:nth-child(2n+1) > th {
+   background-color: #eeeeee;
+}
+
 @mixin rounded($amount) {
   -moz-border-radius: $amount;
   -webkit-border-radius: $amount;

--- a/upstream/app/controllers/api/v1/combinations_controller.rb
+++ b/upstream/app/controllers/api/v1/combinations_controller.rb
@@ -43,6 +43,7 @@ class Api::V1::CombinationsController < Api::V1::V1Controller
     submit_params = {}
     submit_params[:user_agent] = params[:user_agent] || []
     submit_params[:dhcp_fingerprint] = params[:dhcp_fingerprint] || []
+    submit_params[:dhcp6_fingerprint] = params[:dhcp6_fingerprint] || []
     submit_params[:dhcp_vendor] = params[:dhcp_vendor] || []
 
     logger.debug "Submit params : #{submit_params.inspect}"
@@ -51,35 +52,44 @@ class Api::V1::CombinationsController < Api::V1::V1Controller
     empty_dhcp_fingerprint = DhcpFingerprint.find(0)
     empty_dhcp_vendor = DhcpVendor.find(0)
 
-    added = {:user_agent => [], :dhcp_fingerprint => [], :dhcp_vendor => []}
+    added = {:user_agent => [], :dhcp_fingerprint => [], :dhcp6_fingerprint => [], :dhcp_vendor => []}
 
     submit_params[:user_agent].each do |user_agent|
       unless UserAgent.exists?(:value => user_agent)
         logger.info "User agent #{user_agent} doesn't exist. Creating it"
-        user_agent = UserAgent.create(:value => user_agent)
-        Combination.create(:user_agent => user_agent, :submitter => @current_user)
-        added[:user_agent] << user_agent.value
+        combination = Combination.get_or_create(:user_agent => user_agent)
+        combination.update(:submitter => @current_user)
+        added[:user_agent] << user_agent
       end
     end
 
     submit_params[:dhcp_fingerprint].each do |dhcp_fingerprint|
       unless DhcpFingerprint.exists?(:value => dhcp_fingerprint)
         logger.info "DHCP fingerprint #{dhcp_fingerprint} doesn't exist. Creating it"
-        dhcp_fingerprint = DhcpFingerprint.create(:value => dhcp_fingerprint)
-        Combination.create(:dhcp_fingerprint => dhcp_fingerprint, :submitter => @current_user)
-        added[:dhcp_fingerprint] << dhcp_fingerprint.value
+        combination = Combination.get_or_create(:dhcp_fingerprint => dhcp_fingerprint)
+        combination.update(:submitter => @current_user)
+        added[:dhcp_fingerprint] << dhcp_fingerprint
+      end
+    end
+
+    submit_params[:dhcp6_fingerprint].each do |dhcp6_fingerprint|
+      unless Dhcp6Fingerprint.exists?(:value => dhcp6_fingerprint)
+        logger.info "DHCP6 fingerprint #{dhcp6_fingerprint} doesn't exist. Creating it"
+        combination = Combination.get_or_create(:dhcp6_fingerprint => dhcp6_fingerprint)
+        combination.update(:submitter => @current_user)
+        added[:dhcp6_fingerprint] << dhcp6_fingerprint
       end
     end
 
     submit_params[:dhcp_vendor].each do |dhcp_vendor|
       unless DhcpVendor.exists?(:value => dhcp_vendor)
         logger.info "DHCP vendor #{dhcp_vendor} doesn't exist. Creating it"
-        dhcp_vendor = DhcpVendor.create(:value => dhcp_vendor)
-        Combination.create(:dhcp_vendor => dhcp_vendor, :submitter => @current_user)
-        added[:dhcp_vendor] << dhcp_vendor.value
+        combination = Combination.get_or_create(:dhcp_vendor => dhcp_vendor)
+        combination.update(:submitter => @current_user)
+        added[:dhcp_vendor] << dhcp_vendor
       end
     end
-    
+  
     render :json => added
   end
   
@@ -169,42 +179,13 @@ class Api::V1::CombinationsController < Api::V1::V1Controller
     end
 
     beginning_time = Time.now
-    @combination = nil
-    user_agent = UserAgent.where(:value => interogate_params[:user_agent]).first
-    user_agent = UserAgent.create(:value => interogate_params[:user_agent]) unless user_agent
-    logger.info "Matched UA #{user_agent.id} : #{user_agent.value}"
-    end_time = Time.now
-    logger.info "Time elapsed for user agent lookup #{(end_time - beginning_time)*1000} milliseconds"  
-
-    beginning_time = Time.now
-    dhcp_fingerprint = DhcpFingerprint.where(:value => interogate_params[:dhcp_fingerprint]).first
-    dhcp_fingerprint = DhcpFingerprint.create(:value => interogate_params[:dhcp_fingerprint]) unless dhcp_fingerprint
-    logger.info "Matched DHCP fingerprint #{dhcp_fingerprint.id} : #{dhcp_fingerprint.value}"
-    end_time = Time.now
-    logger.info "Time elapsed for dhcp fingerprint lookup #{(end_time - beginning_time)*1000} milliseconds"  
-
-    beginning_time = Time.now
-    dhcp_vendor = DhcpVendor.where(:value => interogate_params[:dhcp_vendor]).first
-    dhcp_vendor = DhcpVendor.create(:value => interogate_params[:dhcp_vendor]) unless dhcp_vendor
-    logger.info "Matched DHCP vendor #{dhcp_vendor.id} : #{dhcp_vendor.value}"
-    end_time = Time.now
-    logger.info "Time elapsed for dhcp vendor lookup #{(end_time - beginning_time)*1000} milliseconds"  
-
-    beginning_time = Time.now
-    mac_vendor = MacVendor.from_mac(interogate_params[:mac])
-    mac_vendor_id = mac_vendor.nil? ? 'NULL' : mac_vendor.id
-    end_time = Time.now
-    logger.info "Time elapsed for mac vendor lookup #{(end_time - beginning_time)*1000} milliseconds"  
-
-    beginning_time = Time.now
-    @combination = Combination.where(:user_agent =>user_agent, :dhcp_fingerprint => dhcp_fingerprint, :dhcp_vendor_id => dhcp_vendor, :mac_vendor => mac_vendor).first
+    @combination = Combination.get_or_create(:user_agent => interogate_params[:user_agent], :dhcp_fingerprint => interogate_params[:dhcp_fingerprint], :dhcp_vendor_id => interogate_params[:dhcp_vendor], :mac => interogate_params[:mac]).first
     end_time = Time.now
     logger.info "Time elapsed for combination lookup #{(end_time - beginning_time)*1000} milliseconds"  
 
-    if @combination.nil?
-      logger.warn "Combination doesn't exist. Creating a new one"
-      Combination.create(:user_agent => user_agent, :dhcp_fingerprint => dhcp_fingerprint, :dhcp_vendor => dhcp_vendor, :mac_vendor => mac_vendor, :submitter => @current_user)
-      @combination = Combination.where(:user_agent => user_agent, :dhcp_fingerprint => dhcp_fingerprint, :dhcp_vendor => dhcp_vendor, :mac_vendor => mac_vendor).first
+    if @combination.just_created
+      logger.warn "Combination didn't exist and was created."
+      @combination.update(:submitter => @current_user)
       @combination.process(:with_version => true, :save => true)
     end
     if @combination.device.nil?

--- a/upstream/app/controllers/api/v1/combinations_controller.rb
+++ b/upstream/app/controllers/api/v1/combinations_controller.rb
@@ -17,8 +17,16 @@ class Api::V1::CombinationsController < Api::V1::V1Controller
     :desc => "The DHCP fingerprints to process", 
     :meta => {'Type' => "payload"}
 
+  param :dhcp6_fingerprint, Array, :of => String,
+    :desc => "The DHCPv6 fingerprints to process", 
+    :meta => {'Type' => "payload"}
+
   param :dhcp_vendor, Array, :of => String,
     :desc => "The DHCP vendors to process", 
+    :meta => {'Type' => "payload"}
+
+  param :dhcp6_enterprise, Array, :of => String,
+    :desc => "The DHCPv6 enterprises to process", 
     :meta => {'Type' => "payload"}
 
   formats ['Request : application/json', 'Response : application/json']
@@ -119,8 +127,16 @@ class Api::V1::CombinationsController < Api::V1::V1Controller
     :desc => "The DHCP fingerprint of the device", 
     :meta => {'Type' => "payload"}
 
+  param :dhcp6_fingerprint, String, 
+    :desc => "The DHCPv6 fingerprint of the device", 
+    :meta => {'Type' => "payload"}
+
   param :dhcp_vendor, String, 
     :desc => "The DHCP vendor of the device", 
+    :meta => {'Type' => "payload"}
+
+  param :dhcp6_enterprise, String, 
+    :desc => "The DHCPv6 enterprise of the device", 
     :meta => {'Type' => "payload"}
 
   param :mac, String, 

--- a/upstream/app/controllers/api/v1/combinations_controller.rb
+++ b/upstream/app/controllers/api/v1/combinations_controller.rb
@@ -179,7 +179,7 @@ class Api::V1::CombinationsController < Api::V1::V1Controller
     end
 
     beginning_time = Time.now
-    @combination = Combination.get_or_create(:user_agent => interogate_params[:user_agent], :dhcp_fingerprint => interogate_params[:dhcp_fingerprint], :dhcp_vendor_id => interogate_params[:dhcp_vendor], :mac => interogate_params[:mac]).first
+    @combination = Combination.get_or_create(:user_agent => interogate_params[:user_agent], :dhcp_fingerprint => interogate_params[:dhcp_fingerprint], :dhcp_vendor_id => interogate_params[:dhcp_vendor], :mac => interogate_params[:mac])
     end_time = Time.now
     logger.info "Time elapsed for combination lookup #{(end_time - beginning_time)*1000} milliseconds"  
 

--- a/upstream/app/controllers/api/v1/combinations_controller.rb
+++ b/upstream/app/controllers/api/v1/combinations_controller.rb
@@ -167,19 +167,20 @@ class Api::V1::CombinationsController < Api::V1::V1Controller
     interogate_params = get_interogate_params
 
     interogate_params[:dhcp_fingerprint] = interogate_params[:dhcp_fingerprint] || ""
+    interogate_params[:dhcp6_fingerprint] = interogate_params[:dhcp6_fingerprint] || ""
     interogate_params[:user_agent] = interogate_params[:user_agent] || ""
     interogate_params[:dhcp_vendor] = interogate_params[:dhcp_vendor] || ""
     interogate_params[:mac] = interogate_params[:mac] || ""
 
     logger.debug "Interogate params : #{interogate_params.inspect}"
 
-    if interogate_params[:user_agent].blank? && interogate_params[:dhcp_fingerprint].blank? && interogate_params[:dhcp_vendor].blank? && interogate_params[:mac].blank?
+    if interogate_params[:user_agent].blank? && interogate_params[:dhcp_fingerprint].blank? && interogate_params[:dhcp_vendor].blank? && interogate_params[:dhcp6_fingerprint].blank? && interogate_params[:mac].blank?
       render json: {:message => 'There is no parameter in your query'}, :status => :bad_request
       return
     end
 
     beginning_time = Time.now
-    @combination = Combination.get_or_create(:user_agent => interogate_params[:user_agent], :dhcp_fingerprint => interogate_params[:dhcp_fingerprint], :dhcp_vendor_id => interogate_params[:dhcp_vendor], :mac => interogate_params[:mac])
+    @combination = Combination.get_or_create(:user_agent => interogate_params[:user_agent], :dhcp_fingerprint => interogate_params[:dhcp_fingerprint], :dhcp6_fingerprint => interogate_params[:dhcp6_fingerprint], :dhcp_vendor => interogate_params[:dhcp_vendor], :mac => interogate_params[:mac])
     end_time = Time.now
     logger.info "Time elapsed for combination lookup #{(end_time - beginning_time)*1000} milliseconds"  
 
@@ -207,7 +208,7 @@ class Api::V1::CombinationsController < Api::V1::V1Controller
 
   private
     def get_interogate_params
-      params.permit(:user_agent, :dhcp_fingerprint, :dhcp_vendor, :mac)
+      params.permit(:user_agent, :dhcp_fingerprint, :dhcp6_fingerprint, :dhcp_vendor, :mac)
     end
 
     def get_submit_params

--- a/upstream/app/controllers/combinations_controller.rb
+++ b/upstream/app/controllers/combinations_controller.rb
@@ -172,7 +172,12 @@ class CombinationsController < ApplicationController
     end
 
     def order_results
-      @order = params[:order] || 'created_at'
+      if params[:order]
+        @order = params[:order]
+      else
+        @order = 'created_at'
+        @default_order = true
+      end
       @order_way = params[:order_way] || 'desc'
       @combinations = @combinations.order("#{@order} #{@order_way}")
     end

--- a/upstream/app/controllers/combinations_controller.rb
+++ b/upstream/app/controllers/combinations_controller.rb
@@ -1,21 +1,31 @@
 class CombinationsController < ApplicationController
   before_action :set_combination, only: [:show, :edit, :update, :destroy, :calculate]
   before_action :set_index_help, only: [:index, :unknown, :unrated]
+  before_action :set_search_fields, only: [:index, :unknown, :unrated]
+  before_action :set_sort_fields, only: [:index, :unknown, :unrated]
   before_action :set_submit_help, only: [:new, :create]
 
   skip_before_filter :ensure_admin, :only => [:new, :create, :unknown, :unrated, :interogate]
   before_filter :ensure_community, :only => [:new, :create]
-  before_filter :search_fields, :only => [:index, :unknown, :unrated]
 
-  def search_fields
-    @search_fields = [
-      {:field => 'user_agents.value', :display => 'User Agent'},
-      {:field => 'dhcp_vendors.value', :display => 'DHCP Vendor'},
-      {:field => 'dhcp_fingerprints.value', :display => 'DhcpFingerprint'},
-      {:field => 'devices.name', :display => 'Device name'},
-      {:field => 'mac_vendors.name', :display => 'Mac vendor name', :type => 'string'},
-      {:field => 'submitters.name', :display => 'Submitter username', :type => 'string'},
-    ]
+  def set_search_fields
+    @search_fields = {
+      'user_agents.value' => 'User Agent',
+      'dhcp_vendors.value' =>  'DHCPv4 Vendor',
+      'dhcp_fingerprints.value' => 'DHCPv4 Fingerprint',
+      'dhcp6_fingerprints.value' => 'DHCPv6 Fingerprint',
+      'dhcp6_enterprises.value' => 'DHCPv6 Enterprise',
+      'devices.name' => 'Device name',
+      'mac_vendors.name'=> 'Mac vendor name',
+      'submitters.name'=> 'Submitter username',
+    }
+    return @search_fields
+  end
+
+  def set_sort_fields
+    @sort_fields = set_search_fields
+    @sort_fields['combinations.score'] = 'Score'
+    return @search_fields
   end
 
   def escaped_search
@@ -23,19 +33,6 @@ class CombinationsController < ApplicationController
     #search = search.gsub!(/[+\-"]/, ' ')
     logger.debug "escaped_search #{search}"
     return search
-  end
-
-  def base_search
-    @selected_fields = params[:fields]
-
-    @search = Combination.simple_search {paginate :page => params[:page], :per_page => 15}if @search.nil?
-    if escaped_search 
-      @search.build do
-        fulltext escaped_search do
-          fields(*params[:fields]) unless params[:fields].nil? 
-        end
-      end
-    end
   end
 
   # GET /combinations

--- a/upstream/app/helpers/combinations_helper.rb
+++ b/upstream/app/helpers/combinations_helper.rb
@@ -1,9 +1,15 @@
 module CombinationsHelper
   def sorting_link(label, column_name)
+    return raw("<a href='?#{request.parameters.merge({:order => column_name, :order_way => (@order == column_name && @order_way == 'desc') ? 'asc' : 'desc' }).to_param}'>#{sorting_span(label, column_name)}</a>")
+  end
+
+  def sorting_span(label, column_name)
     span_class = ''
     if @order == column_name
       span_class = @order_way == 'desc' ? "glyphicon glyphicon-arrow-down" : "glyphicon glyphicon-arrow-up"
     end
-    return raw("<a href='?#{request.parameters.merge({:order => column_name, :order_way => (@order == column_name && @order_way == 'desc') ? 'asc' : 'desc' }).to_param}'>#{label} #{content_tag(:span, '', :class=>span_class)}</a>")
+
+    return raw("#{label} #{content_tag(:span, '', :class=>span_class)}")
   end
+
 end

--- a/upstream/app/helpers/combinations_helper.rb
+++ b/upstream/app/helpers/combinations_helper.rb
@@ -1,6 +1,10 @@
 module CombinationsHelper
   def sorting_link(label, column_name)
-    return raw("<a href='?#{request.parameters.merge({:order => column_name, :order_way => (@order == column_name && @order_way == 'desc') ? 'asc' : 'desc' }).to_param}'>#{sorting_span(label, column_name)}</a>")
+    return raw("<a href='?#{sorting_request(column_name)}'>#{sorting_span(label, column_name)}</a>")
+  end
+
+  def sorting_request(column_name)
+    request.parameters.merge({:order => column_name, :order_way => (@order == column_name && @order_way == 'desc') ? 'asc' : 'desc' }).to_param
   end
 
   def sorting_span(label, column_name)

--- a/upstream/app/models/combination.rb
+++ b/upstream/app/models/combination.rb
@@ -2,6 +2,7 @@ require 'combination/detection'
 
 class Combination < FingerbankModel
   belongs_to :dhcp_fingerprint
+  belongs_to :dhcp6_fingerprint
   belongs_to :user_agent
   belongs_to :dhcp_vendor
   belongs_to :device
@@ -9,14 +10,10 @@ class Combination < FingerbankModel
 
   belongs_to :submitter, :class_name => "User"
 
-  before_validation :on => :create do
-    set_empty
-  end
-
   attr_accessor :processed_method
 
   #validates_uniqueness_of :dhcp_fingerprint_id, :scope => [ :user_agent_id, :dhcp_vendor_id ], :message => "A combination with these attributes already exists"
-  validates_presence_of :dhcp_fingerprint_id, :dhcp_vendor_id, :user_agent_id
+  validates_presence_of :dhcp_fingerprint_id, :dhcp6_fingerprint_id, :dhcp_vendor_id, :user_agent_id
   validate :validate_combination_uniqueness
 
   scope :unknown, -> {where(:device => nil)}   
@@ -37,16 +34,38 @@ class Combination < FingerbankModel
     }
   end
 
-  def set_empty
-    self.user_agent_id = 0 unless self.user_agent_id
-    self.dhcp_fingerprint_id = 0 unless self.dhcp_fingerprint_id
-    self.dhcp_vendor_id = 0 unless self.dhcp_vendor_id
+  def just_created
+    if @just_created
+      true
+    else
+      false
+    end
+  end
+
+  def just_created=(value)
+    @just_created = value
+  end
+
+  def self.get_or_create(values)
+    dhcp_fingerprint = DhcpFingerprint.get_or_create(:value => values[:dhcp_fingerprint])
+    dhcp6_fingerprint = Dhcp6Fingerprint.get_or_create(:value => values[:dhcp6_fingerprint])
+    dhcp_vendor = DhcpVendor.get_or_create(:value => values[:dhcp_vendor])
+    user_agent = UserAgent.get_or_create(:value => values[:user_agent])
+    mac_vendor = MacVendor.from_mac(values[:mac])
+    combination = Combination.where(:dhcp_fingerprint_id => dhcp_fingerprint.id, :dhcp6_fingerprint_id => dhcp6_fingerprint.id, :user_agent_id => user_agent.id, :dhcp_vendor_id => dhcp_vendor.id, :mac_vendor => mac_vendor).first
+    if combination.nil?
+      combination = self.create!(:dhcp_fingerprint => dhcp_fingerprint, :dhcp6_fingerprint => dhcp6_fingerprint, :user_agent => user_agent, :dhcp_vendor => dhcp_vendor, :mac_vendor => mac_vendor)
+      combination.just_created = true
+      return combination
+    else
+      return combination
+    end
   end
 
   def validate_combination_uniqueness
-    existing = Combination.where(:dhcp_fingerprint_id => dhcp_fingerprint_id, :user_agent_id => user_agent_id, :dhcp_vendor_id => dhcp_vendor_id, :mac_vendor_id => mac_vendor_id).size
+    existing = Combination.where(:dhcp_fingerprint_id => dhcp_fingerprint_id, :dhcp6_fingerprint_id => dhcp6_fingerprint_id, :user_agent_id => user_agent_id, :dhcp_vendor_id => dhcp_vendor_id, :mac_vendor_id => mac_vendor_id).size
     if (persisted? && existing > 1) || (!persisted? && existing > 0)
-      logger.warn "Combination #{id} was going to be saved, but a duplicate was found with dhcp_fingerprint_id #{dhcp_fingerprint_id}, user_agent_id #{user_agent_id}, dhcp_vendor_id #{dhcp_vendor_id}, mac_vendor_id #{mac_vendor_id}"
+      logger.warn "Combination #{id} was going to be saved, but a duplicate was found with dhcp_fingerprint_id #{dhcp_fingerprint_id}, dhcp6_fingerprint_id #{dhcp6_fingerprint_id}, user_agent_id #{user_agent_id}, dhcp_vendor_id #{dhcp_vendor_id}, mac_vendor_id #{mac_vendor_id}"
       errors.add(:combination, 'A unique set of attributes must be set. This combination already exists')
     end
   end

--- a/upstream/app/models/combination.rb
+++ b/upstream/app/models/combination.rb
@@ -26,6 +26,8 @@ class Combination < FingerbankModel
       :has => [],
       :belongs_to => [
         :dhcp_fingerprint,
+        :dhcp6_fingerprint,
+        :dhcp6_enterprise,
         :user_agent,
         :dhcp_vendor,
         :mac_vendor,

--- a/upstream/app/models/combination.rb
+++ b/upstream/app/models/combination.rb
@@ -124,5 +124,10 @@ class Combination < FingerbankModel
     end
   end
 
+  def create_temp_combination
+    mac_vendor_name = mac_vendor ? mac_vendor.name : ''
+    return TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :dhcp6_enterprise => dhcp6_enterprise.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+  end
+
 end
 

--- a/upstream/app/models/combination.rb
+++ b/upstream/app/models/combination.rb
@@ -50,7 +50,7 @@ class Combination < FingerbankModel
   def self.get_or_create(values)
     dhcp_fingerprint = DhcpFingerprint.get_or_create(:value => values[:dhcp_fingerprint])
     dhcp6_fingerprint = Dhcp6Fingerprint.get_or_create(:value => values[:dhcp6_fingerprint])
-    dhcp6_enterprise = Dhcp6Fingerprint.get_or_create(:value => values[:dhcp6_enterprise])
+    dhcp6_enterprise = Dhcp6Enterprise.get_or_create(:value => values[:dhcp6_enterprise])
     dhcp_vendor = DhcpVendor.get_or_create(:value => values[:dhcp_vendor])
     user_agent = UserAgent.get_or_create(:value => values[:user_agent])
     mac_vendor = MacVendor.from_mac(values[:mac])

--- a/upstream/app/models/combination/detection.rb
+++ b/upstream/app/models/combination/detection.rb
@@ -119,8 +119,7 @@ class Combination < FingerbankModel
 
     ua = user_agent.value
     discoverers = []
-    mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :dhcp6_enterprise => dhcp6_enterprise.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = self.create_temp_combination
     assoc.each do |regex, discoverer|
       if ua =~ /#{regex}/ && temp_combination.matches?(discoverer)
          discoverers << discoverer
@@ -140,8 +139,7 @@ class Combination < FingerbankModel
     ifs, conditions = Discoverer.discoverers_ifs
     matches = []
 
-    mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :dhcp6_enterprise => dhcp6_enterprise.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = self.create_temp_combination
     unless ifs.empty?
       return temp_combination.matches_on_ifs?(ifs, conditions)   
       self.processed_method = "find_matching_discoverers_tmp_table"
@@ -155,8 +153,7 @@ class Combination < FingerbankModel
     discoverers = Discoverer.all
     discoverers_matched = []
     
-    mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :dhcp6_enterprise => dhcp6_enterprise.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = self.create_temp_combination
     discoverers.each do |discoverer|
       if temp_combination.matches?(discoverer)
         discoverers_matched << discoverer
@@ -177,8 +174,7 @@ class Combination < FingerbankModel
       return
     end
 
-    mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :dhcp6_enterprise => dhcp6_enterprise.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = self.create_temp_combination
     valid_discoverers = temp_combination.matches_on_ifs?(version_discoverers_ifs[:ifs], version_discoverers_ifs[:conditions])
     versions_discovered = {} 
     valid_discoverers.each do |discoverer|

--- a/upstream/app/models/combination/detection.rb
+++ b/upstream/app/models/combination/detection.rb
@@ -43,6 +43,7 @@ class Combination < FingerbankModel
               inner join user_agents on user_agents.id=combinations.user_agent_id 
               inner join dhcp_fingerprints on dhcp_fingerprints.id=combinations.dhcp_fingerprint_id
               inner join dhcp6_fingerprints on dhcp6_fingerprints.id=combinations.dhcp6_fingerprint_id
+              inner join dhcp6_enterprises on dhcp6_enterprises.id=combinations.dhcp6_enterprise_id
               inner join dhcp_vendors on dhcp_vendors.id=combinations.dhcp_vendor_id
               left join mac_vendors on mac_vendors.id=combinations.mac_vendor_id
               WHERE (combinations.id=#{id}) AND #{computed};"
@@ -59,6 +60,7 @@ class Combination < FingerbankModel
               inner join user_agents on user_agents.id=combinations.user_agent_id 
               inner join dhcp_fingerprints on dhcp_fingerprints.id=combinations.dhcp_fingerprint_id
               inner join dhcp6_fingerprints on dhcp6_fingerprints.id=combinations.dhcp6_fingerprint_id
+              inner join dhcp6_enterprises on dhcp6_enterprises.id=combinations.dhcp6_enterprise_id
               inner join dhcp_vendors on dhcp_vendors.id=combinations.dhcp_vendor_id
               left join mac_vendors on mac_vendors.id=combinations.mac_vendor_id
               WHERE (combinations.id=#{id}) AND #{computed};"
@@ -118,7 +120,7 @@ class Combination < FingerbankModel
     ua = user_agent.value
     discoverers = []
     mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :dhcp6_enterprise => dhcp6_enterprise.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
     assoc.each do |regex, discoverer|
       if ua =~ /#{regex}/ && temp_combination.matches?(discoverer)
          discoverers << discoverer
@@ -139,7 +141,7 @@ class Combination < FingerbankModel
     matches = []
 
     mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :dhcp6_enterprise => dhcp6_enterprise.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
     unless ifs.empty?
       return temp_combination.matches_on_ifs?(ifs, conditions)   
       self.processed_method = "find_matching_discoverers_tmp_table"
@@ -154,7 +156,7 @@ class Combination < FingerbankModel
     discoverers_matched = []
     
     mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :dhcp6_enterprise => dhcp6_enterprise.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
     discoverers.each do |discoverer|
       if temp_combination.matches?(discoverer)
         discoverers_matched << discoverer
@@ -176,7 +178,7 @@ class Combination < FingerbankModel
     end
 
     mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :dhcp6_enterprise => dhcp6_enterprise.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
     valid_discoverers = temp_combination.matches_on_ifs?(version_discoverers_ifs[:ifs], version_discoverers_ifs[:conditions])
     versions_discovered = {} 
     valid_discoverers.each do |discoverer|
@@ -193,6 +195,7 @@ class Combination < FingerbankModel
             inner join user_agents on user_agents.id=combinations.user_agent_id 
             inner join dhcp_fingerprints on dhcp_fingerprints.id=combinations.dhcp_fingerprint_id
             inner join dhcp6_fingerprints on dhcp6_fingerprints.id=combinations.dhcp6_fingerprint_id
+            inner join dhcp6_enterprises on dhcp6_enterprises.id=combinations.dhcp6_enterprise_id
             inner join dhcp_vendors on dhcp_vendors.id=combinations.dhcp_vendor_id
             left join mac_vendors on mac_vendors.id=combinations.mac_vendor_id
             WHERE (combinations.id=#{id});"

--- a/upstream/app/models/combination/detection.rb
+++ b/upstream/app/models/combination/detection.rb
@@ -42,6 +42,7 @@ class Combination < FingerbankModel
       sql = "SELECT combinations.id from combinations 
               inner join user_agents on user_agents.id=combinations.user_agent_id 
               inner join dhcp_fingerprints on dhcp_fingerprints.id=combinations.dhcp_fingerprint_id
+              inner join dhcp6_fingerprints on dhcp6_fingerprints.id=combinations.dhcp6_fingerprint_id
               inner join dhcp_vendors on dhcp_vendors.id=combinations.dhcp_vendor_id
               left join mac_vendors on mac_vendors.id=combinations.mac_vendor_id
               WHERE (combinations.id=#{id}) AND #{computed};"
@@ -57,6 +58,7 @@ class Combination < FingerbankModel
       sql = "SELECT combinations.id from combinations 
               inner join user_agents on user_agents.id=combinations.user_agent_id 
               inner join dhcp_fingerprints on dhcp_fingerprints.id=combinations.dhcp_fingerprint_id
+              inner join dhcp6_fingerprints on dhcp6_fingerprints.id=combinations.dhcp6_fingerprint_id
               inner join dhcp_vendors on dhcp_vendors.id=combinations.dhcp_vendor_id
               left join mac_vendors on mac_vendors.id=combinations.mac_vendor_id
               WHERE (combinations.id=#{id}) AND #{computed};"
@@ -116,7 +118,7 @@ class Combination < FingerbankModel
     ua = user_agent.value
     discoverers = []
     mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
     assoc.each do |regex, discoverer|
       if ua =~ /#{regex}/ && temp_combination.matches?(discoverer)
          discoverers << discoverer
@@ -137,7 +139,7 @@ class Combination < FingerbankModel
     matches = []
 
     mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
     unless ifs.empty?
       return temp_combination.matches_on_ifs?(ifs, conditions)   
       self.processed_method = "find_matching_discoverers_tmp_table"
@@ -152,7 +154,7 @@ class Combination < FingerbankModel
     discoverers_matched = []
     
     mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
     discoverers.each do |discoverer|
       if temp_combination.matches?(discoverer)
         discoverers_matched << discoverer
@@ -174,7 +176,7 @@ class Combination < FingerbankModel
     end
 
     mac_vendor_name = mac_vendor ? mac_vendor.name : ''
-    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
+    temp_combination = TempCombination.create!(:dhcp_fingerprint => dhcp_fingerprint.value, :dhcp6_fingerprint => dhcp6_fingerprint.value, :user_agent => user_agent.value, :dhcp_vendor => dhcp_vendor.value, :mac_vendor => mac_vendor_name)
     valid_discoverers = temp_combination.matches_on_ifs?(version_discoverers_ifs[:ifs], version_discoverers_ifs[:conditions])
     versions_discovered = {} 
     valid_discoverers.each do |discoverer|
@@ -190,6 +192,7 @@ class Combination < FingerbankModel
     sql = "SELECT #{discoverer.version_finder} from combinations 
             inner join user_agents on user_agents.id=combinations.user_agent_id 
             inner join dhcp_fingerprints on dhcp_fingerprints.id=combinations.dhcp_fingerprint_id
+            inner join dhcp6_fingerprints on dhcp6_fingerprints.id=combinations.dhcp6_fingerprint_id
             inner join dhcp_vendors on dhcp_vendors.id=combinations.dhcp_vendor_id
             left join mac_vendors on mac_vendors.id=combinations.mac_vendor_id
             WHERE (combinations.id=#{id});"

--- a/upstream/app/models/combination_attribute.rb
+++ b/upstream/app/models/combination_attribute.rb
@@ -1,0 +1,24 @@
+class CombinationAttribute < ActiveRecord::Base
+
+  self.abstract_class = true
+
+  has_many :combinations
+
+  default_scope { order('value') }
+
+  validates_uniqueness_of :value
+
+  def self.get_or_create(vals)
+    vals[:value] = vals[:value] || ''
+    found = self.where(vals).first
+    if found.nil?
+      created = self.create(vals)
+      logger.debug "#{self.to_s} not found creating with ID #{created.id}"
+      return created
+    else
+      logger.debug "#{self.to_s} found with id #{found.id}"
+      return found
+    end
+  end
+
+end

--- a/upstream/app/models/dhcp6_enterprise.rb
+++ b/upstream/app/models/dhcp6_enterprise.rb
@@ -1,0 +1,2 @@
+class Dhcp6Enterprise < ActiveRecord::Base
+end

--- a/upstream/app/models/dhcp6_enterprise.rb
+++ b/upstream/app/models/dhcp6_enterprise.rb
@@ -1,2 +1,2 @@
-class Dhcp6Enterprise < ActiveRecord::Base
+class Dhcp6Enterprise < CombinationAttribute
 end

--- a/upstream/app/models/dhcp6_fingerprint.rb
+++ b/upstream/app/models/dhcp6_fingerprint.rb
@@ -1,0 +1,2 @@
+class Dhcp6Fingerprint < CombinationAttribute
+end

--- a/upstream/app/models/dhcp_fingerprint.rb
+++ b/upstream/app/models/dhcp_fingerprint.rb
@@ -1,12 +1,4 @@
-class DhcpFingerprint < ActiveRecord::Base
-
-  has_many :combinations
-
-  default_scope { order('value') }
-
-  validates_uniqueness_of :value
-
+class DhcpFingerprint < CombinationAttribute
   scope :ignored, -> {where(:ignored => true)}
   scope :not_ignored, -> {where(:ignored => false)}
-
 end

--- a/upstream/app/models/dhcp_vendor.rb
+++ b/upstream/app/models/dhcp_vendor.rb
@@ -1,7 +1,2 @@
-class DhcpVendor < ActiveRecord::Base
-
-  has_many :combinations
-
-  validates_uniqueness_of :value
-
+class DhcpVendor < CombinationAttribute
 end

--- a/upstream/app/models/discoverer.rb
+++ b/upstream/app/models/discoverer.rb
@@ -50,6 +50,7 @@ class Discoverer < FingerbankModel
               inner join user_agents on user_agents.id=combinations.user_agent_id 
               inner join dhcp_fingerprints on dhcp_fingerprints.id=combinations.dhcp_fingerprint_id
               inner join dhcp6_fingerprints on dhcp6_fingerprints.id=combinations.dhcp6_fingerprint_id
+              inner join dhcp6_enterprises on dhcp6_enterprises.id=combinations.dhcp6_enterprise_id
               inner join dhcp_vendors on dhcp_vendors.id=combinations.dhcp_vendor_id
               left join mac_vendors on mac_vendors.id=combinations.mac_vendor_id
               WHERE (#{query});"

--- a/upstream/app/models/discoverer.rb
+++ b/upstream/app/models/discoverer.rb
@@ -49,6 +49,7 @@ class Discoverer < FingerbankModel
       sql = "SELECT combinations.id from combinations 
               inner join user_agents on user_agents.id=combinations.user_agent_id 
               inner join dhcp_fingerprints on dhcp_fingerprints.id=combinations.dhcp_fingerprint_id
+              inner join dhcp6_fingerprints on dhcp6_fingerprints.id=combinations.dhcp6_fingerprint_id
               inner join dhcp_vendors on dhcp_vendors.id=combinations.dhcp_vendor_id
               left join mac_vendors on mac_vendors.id=combinations.mac_vendor_id
               WHERE (#{query});"

--- a/upstream/app/models/fingerbank_cache/discoverer.rb
+++ b/upstream/app/models/fingerbank_cache/discoverer.rb
@@ -118,6 +118,7 @@ class Discoverer < FingerbankModel
 
   def self.rule_for_tmp_table(rule)
     to_add = rule.computed.gsub('dhcp_fingerprints.value', 'dhcp_fingerprint')
+    to_add = to_add.gsub('dhcp6_fingerprints.value', 'dhcp6_fingerprint')
     to_add = to_add.gsub('user_agents.value', 'user_agent')
     to_add = to_add.gsub('dhcp_vendors.value', 'dhcp_vendor')
     to_add = to_add.gsub('mac_vendors.name', 'mac_vendor')

--- a/upstream/app/models/fingerbank_cache/discoverer.rb
+++ b/upstream/app/models/fingerbank_cache/discoverer.rb
@@ -119,6 +119,7 @@ class Discoverer < FingerbankModel
   def self.rule_for_tmp_table(rule)
     to_add = rule.computed.gsub('dhcp_fingerprints.value', 'dhcp_fingerprint')
     to_add = to_add.gsub('dhcp6_fingerprints.value', 'dhcp6_fingerprint')
+    to_add = to_add.gsub('dhcp6_enterprises.value', 'dhcp6_enterprise')
     to_add = to_add.gsub('user_agents.value', 'user_agent')
     to_add = to_add.gsub('dhcp_vendors.value', 'dhcp_vendor')
     to_add = to_add.gsub('mac_vendors.name', 'mac_vendor')

--- a/upstream/app/models/user_agent.rb
+++ b/upstream/app/models/user_agent.rb
@@ -1,7 +1,2 @@
-class UserAgent < ActiveRecord::Base
-
-  has_many :combinations
-
-  validates_uniqueness_of :value
-
+class UserAgent < CombinationAttribute
 end

--- a/upstream/app/views/combinations/_combination.html.erb
+++ b/upstream/app/views/combinations/_combination.html.erb
@@ -1,0 +1,45 @@
+
+<% if combination.device %>
+  <% parents = combination.device.parents.reverse %>
+  <ul class="list-group">
+    <li class="list-group-item active"><strong>Hierarchy</strong></li>
+  <% parents.each do |parent| %>
+    <li class="list-group-item"><%= parent.name %></li>
+  <% end %>
+    <li class="list-group-item"><%= combination.device.name %></li>
+  </ul>
+<% end %>
+
+<p>
+  <strong>MAC Vendor:</strong>
+  <% if combination.mac_vendor %>
+    <%= combination.mac_vendor.name %> (<%= combination.mac_vendor.mac %>)
+  <% else %>
+    Unknown
+  <% end %>
+</p>
+
+<p>
+  <strong>User agent:</strong>
+  <pre><%= combination.user_agent.value %></pre>
+</p>
+
+<p>
+  <strong>DHCPv4 fingerprint:</strong>
+  <pre><%= combination.dhcp_fingerprint.value %></pre>
+</p>
+
+<p>
+  <strong>DHCPv4 Vendor:</strong>
+  <pre><%= combination.dhcp_vendor.value %></pre>
+</p>
+
+<p>
+  <strong>DHCPv6 fingerprint:</strong>
+  <pre><%= combination.dhcp6_fingerprint.value %></pre>
+</p>
+
+<p>
+  <strong>DHCPv6 enterprise:</strong>
+  <pre><%= combination.dhcp6_enterprise.value %></pre>
+</p>

--- a/upstream/app/views/combinations/_options.html.erb
+++ b/upstream/app/views/combinations/_options.html.erb
@@ -1,0 +1,8 @@
+<%= link_to '', edit_combination_path(combination), :class => "btn-edit" if current_user_admin? %>
+
+<%= link_to '', combination, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn-delete' if current_user_admin? %>
+
+<%= link_to '', calculate_combination_path(combination), :class => "btn-refresh" if current_user_admin? %>
+
+<%= link_to '', user_watched_combinations_path(@current_user, combination_id: combination.id), method: :post, :class => "btn-watch" unless @current_user.nil? %>
+

--- a/upstream/app/views/combinations/_search.html.erb
+++ b/upstream/app/views/combinations/_search.html.erb
@@ -12,7 +12,7 @@
     <% end %>
     <div id="advanced_fields" style="<%= @selected_fields.nil? ? 'display:none' : '' %>">
       <label>Filter on :</label><br/>
-      <%= select_tag :fields, options_for_select(@search_fields.collect {|f| [ f[:display], f[:field] ] }, :selected => @selected_fields), :multiple => true %> 
+      <%= select_tag :fields, options_for_select(@search_fields.collect {|field,display| [ display, field ] }, :selected => @selected_fields), :multiple => true %> 
     </div>
 
   <% end %>

--- a/upstream/app/views/combinations/_summary.html.erb
+++ b/upstream/app/views/combinations/_summary.html.erb
@@ -1,0 +1,10 @@
+
+<h4><%= combination.device ? combination.device.name : "Unknown device" %></h4>
+<% if combination.version %>
+<span class="label label-success">Version : <%= combination.version %></span>
+<% else %>
+<span class="label label-warning">Unknown version</span>
+<% end %>
+<span class="label label-primary">Score : <%= combination.score %></span>
+
+

--- a/upstream/app/views/combinations/index.html.erb
+++ b/upstream/app/views/combinations/index.html.erb
@@ -1,28 +1,41 @@
 
-
+<div id="combination_details" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <div class="modal-title"></div>
+      </div>
+      <div class="modal-body">
+      </div>
+      <div class="modal-footer">
+        <div class="options"></div>
+        <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 <div>
 
+  <div class="btn-group" style="float:left">
+    <a href="?<%= @default_order ? '' : sorting_request(@order) %>" class="btn btn-primary">
+      <%= @default_order ? 'Sort by' : sorting_span(@sort_fields[@order], @order) %>
+    </a>
+    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+      <span class="caret"></span>
+      <span class="sr-only">Toggle Dropdown</span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+      <% @sort_fields.each do |field, display| %>
+        <li><%= sorting_link display, field %></li>
+      <% end %>
+
+      <li><%= sorting_link 'Discovered when', 'created_at' %></li>
 
 
-<div class="btn-group" style="float:left">
-  <a href="?<%= @default_order ? '' : sorting_request(@order) %>" class="btn btn-primary">
-    <%= @default_order ? 'Sort by' : sorting_span(@sort_fields[@order], @order) %>
-  </a>
-  <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-    <span class="caret"></span>
-    <span class="sr-only">Toggle Dropdown</span>
-  </button>
-  <ul class="dropdown-menu" role="menu">
-    <% @sort_fields.each do |field, display| %>
-      <li><%= sorting_link display, field %></li>
-    <% end %>
-
-    <li><%= sorting_link 'Discovered when', 'created_at' %></li>
-
-
-  </ul>
-</div>
+    </ul>
+  </div>
 
   <%= render :partial => 'search' %>
 
@@ -40,7 +53,6 @@
 <table class="table-striped">
   <thead>
     <tr>
-      <th></th>
       <th>Device</th>
       <th>Submitter</th>
       <th>User agent</th>
@@ -59,14 +71,8 @@
 
   <tbody>
     <% @combinations.each do |combination| %>
-      <tr>
-        <td class="options">
-          <%= link_to '', combination, :class => "btn-show" %>
-          <%= link_to '', edit_combination_path(combination), :class => "btn-edit" if current_user_admin? %>
-          <%= link_to '', combination, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn-delete' if current_user_admin? %>
-          <%= link_to '', calculate_combination_path(combination), :class => "btn-refresh" if current_user_admin? %>
-          <%= link_to '', user_watched_combinations_path(@current_user, combination_id: combination.id), method: :post, :class => "btn-watch" unless @current_user.nil? %>
-        </td>
+      <%= link_to '', combination, :class => "hidden", :remote => true, :id => "show_#{combination.id}" %>
+      <tr class="combination" data-combination-id="<%= combination.id %>">
         <td class="device_info shortened hover-popup" 
           data-details="
             <%= combination.device ? combination.device.full_path : "Unknown" %>

--- a/upstream/app/views/combinations/index.html.erb
+++ b/upstream/app/views/combinations/index.html.erb
@@ -6,7 +6,9 @@
 
 
 <div class="btn-group" style="float:left">
-  <button type="button" class="btn btn-primary"><%= sorting_span @sort_fields[@order], @order %></button>
+  <a href="?<%= @default_order ? '' : sorting_request(@order) %>" class="btn btn-primary">
+    <%= @default_order ? 'Sort by' : sorting_span(@sort_fields[@order], @order) %>
+  </a>
   <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
     <span class="caret"></span>
     <span class="sr-only">Toggle Dropdown</span>
@@ -39,19 +41,19 @@
   <thead>
     <tr>
       <th></th>
-      <th><%= sorting_link 'Device', 'devices.name' %></th>
+      <th>Device</th>
       <th>Submitter</th>
-      <th><%= sorting_link 'User agent', 'user_agents.value' %></th>
+      <th>User agent</th>
       <th>
-        <%= sorting_link 'DHCPv4 fingerprint', 'dhcp_fingerprints.value' %><br/>
-        <%= sorting_link 'DHCPv4 vendor', 'dhcp_vendors.value' %>
+        DHCPv4 fingerprint<br/>
+        DHCPv4 vendor
       </th>
       <th>
-        <%= sorting_link 'DHCPv6 fingerprint', 'dhcp6_fingerprints.value' %><br/>
-        <%= sorting_link 'DHCPv6 enterprise', 'dhcp6_enterprises.value' %>
+        DHCPv6 fingerprint<br/>
+        DHCPv6 enterprise
       </th>
-      <th><%= sorting_link 'Mac vendor', 'mac_vendors.name' %></th>
-      <th><%= sorting_link 'Discovered when', 'created_at' %></th>
+      <th>Mac vendor</th>
+      <th>Discovered when</th>
     </tr>
   </thead>
 
@@ -67,8 +69,7 @@
         </td>
         <td class="device_info shortened hover-popup" 
           data-details="
-            <%= combination.device ? combination.device.full_path : "Unknown" %><br/>
-            Version : <%= combination.version ? combination.version : "Unknown" %>
+            <%= combination.device ? combination.device.full_path : "Unknown" %>
           ">
           <span><%= combination.device ? combination.device.name : "Unknown" %></span>
           <br/>

--- a/upstream/app/views/combinations/index.html.erb
+++ b/upstream/app/views/combinations/index.html.erb
@@ -1,4 +1,26 @@
+
+
+
 <div>
+
+
+
+<div class="btn-group" style="float:left">
+  <button type="button" class="btn btn-primary"><%= sorting_span @sort_fields[@order], @order %></button>
+  <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+    <span class="caret"></span>
+    <span class="sr-only">Toggle Dropdown</span>
+  </button>
+  <ul class="dropdown-menu" role="menu">
+    <% @sort_fields.each do |field, display| %>
+      <li><%= sorting_link display, field %></li>
+    <% end %>
+
+    <li><%= sorting_link 'Discovered when', 'created_at' %></li>
+
+
+  </ul>
+</div>
 
   <%= render :partial => 'search' %>
 

--- a/upstream/app/views/combinations/index.html.erb
+++ b/upstream/app/views/combinations/index.html.erb
@@ -18,13 +18,17 @@
     <tr>
       <th></th>
       <th><%= sorting_link 'Device', 'devices.name' %></th>
-      <th><%= sorting_link 'Score', 'score' %></th>
-      <th><%= sorting_link 'Version', 'version' %></th>
       <th>Submitter</th>
-      <th><%= sorting_link 'Mac vendor', 'mac_vendors.name' %></th>
       <th><%= sorting_link 'User agent', 'user_agents.value' %></th>
-      <th><%= sorting_link 'DHCP fingerprint', 'dhcp_fingerprints.value' %></th>
-      <th><%= sorting_link 'DHCP vendor', 'dhcp_vendors.value' %></th>
+      <th>
+        <%= sorting_link 'DHCPv4 fingerprint', 'dhcp_fingerprints.value' %><br/>
+        <%= sorting_link 'DHCPv4 vendor', 'dhcp_vendors.value' %>
+      </th>
+      <th>
+        <%= sorting_link 'DHCPv6 fingerprint', 'dhcp6_fingerprints.value' %><br/>
+        <%= sorting_link 'DHCPv6 enterprise', 'dhcp6_enterprises.value' %>
+      </th>
+      <th><%= sorting_link 'Mac vendor', 'mac_vendors.name' %></th>
       <th><%= sorting_link 'Discovered when', 'created_at' %></th>
     </tr>
   </thead>
@@ -39,14 +43,34 @@
           <%= link_to '', calculate_combination_path(combination), :class => "btn-refresh" if current_user_admin? %>
           <%= link_to '', user_watched_combinations_path(@current_user, combination_id: combination.id), method: :post, :class => "btn-watch" unless @current_user.nil? %>
         </td>
-        <td class="shortened hover-popup" data-details="<%= combination.device ? combination.device.full_path : "Unknown" %>"><%= combination.device ? combination.device.name : "Unknown" %></td>
-        <td><%= combination.score %>
-        <td><%= combination.version %></td>
+        <td class="device_info shortened hover-popup" 
+          data-details="
+            <%= combination.device ? combination.device.full_path : "Unknown" %><br/>
+            Version : <%= combination.version ? combination.version : "Unknown" %>
+          ">
+          <span><%= combination.device ? combination.device.name : "Unknown" %></span>
+          <br/>
+          <% if combination.version %>
+          <span class="label label-success">Version : <%= combination.version %></span>
+          <% else %>
+          <span class="label label-warning">Unknown version</span>
+          <% end %>
+          <span class="label label-primary">Score : <%= combination.score %></span>
+        </td>
         <td><%= combination.submitter ? combination.submitter.name : '' %></td>
-        <td class="shortened hover-popup"><%= combination.mac_vendor ? combination.mac_vendor.name : "Unknown" %></td>
         <td class="shortened hover-popup"><%= combination.user_agent ? combination.user_agent.value : "Unknown" %></td>
-        <td class="shortened hover-popup"><%= combination.dhcp_fingerprint ? combination.dhcp_fingerprint.value : "Unknown" %></td>
-        <td class="shortened hover-popup"><%= combination.dhcp_vendor ? combination.dhcp_vendor.value : "Unknown" %></td>
+        <td class="shortened hover-popup">
+          <span><%= combination.dhcp_fingerprint.value %></span>
+          <span class="splitter"></span>
+          <span><%= combination.dhcp_vendor.value %></span>
+        </td>
+        <td class="shortened hover-popup">
+          <span><%= combination.dhcp6_fingerprint.value %></span>
+          <span class="splitter"></span>
+          <span ><%= combination.dhcp6_enterprise.value %></span>
+        </td>
+        <td class="shortened hover-popup"><%= combination.mac_vendor ? combination.mac_vendor.name : "Unknown" %></td>
+
         <td><%= time_ago_in_words(combination.created_at) %> ago</td>
       </tr>
     <% end %>

--- a/upstream/app/views/combinations/show.html.erb
+++ b/upstream/app/views/combinations/show.html.erb
@@ -1,41 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<p>
-  <strong>Device:</strong>
-  <%= @combination.device ? @combination.device.name : "Unknown" %>
-</p>
-
-<p>
-  <strong>Version:</strong>
-  <%= @combination.version %>
-</p>
-
-<p>
-  <strong>Score:</strong>
-  <%= @combination.score %>
-</p>
-
-<p>
-  <strong>User agent:</strong>
-  <%= @combination.user_agent.value %>
-</p>
-
-<p>
-  <strong>DhcpFingerprint:</strong>
-  <%= @combination.dhcp_fingerprint.value %>
-</p>
-
-<p>
-  <strong>DHCP Vendor:</strong>
-  <%= @combination.dhcp_vendor.value %>
-</p>
-
-<p>
-  <strong>MAC Vendor:</strong>
-  <% if @combination.mac_vendor %>
-    <%= @combination.mac_vendor.name %> (<%= @combination.mac_vendor.mac %>)
-  <% end %>
-</p>
+<%= render @combination %>
 
 <%= link_to 'Edit', edit_combination_path(@combination) if current_user_admin? %> 
 <%= link_to 'Delete', @combination, method: :delete, data: { confirm: 'Are you sure?' } if current_user_admin? %>

--- a/upstream/app/views/combinations/show.js.erb
+++ b/upstream/app/views/combinations/show.js.erb
@@ -1,0 +1,12 @@
+
+$('#combination_details .modal-title').html(
+    "<%= escape_javascript(render(:partial => 'summary', :locals => { :combination => @combination } ))%>"
+);
+
+$('#combination_details .modal-body').html("<%= escape_javascript(render(:partial => @combination)) %>");
+
+$('#combination_details .modal-footer .options').html(
+  "<%= escape_javascript(render(:partial => 'options', :locals => { :combination => @combination } ))%>"
+);
+
+$('#combination_details').modal('show');

--- a/upstream/app/views/layouts/application.html.erb
+++ b/upstream/app/views/layouts/application.html.erb
@@ -2,10 +2,21 @@
 <html>
 <head>
   <title>Fingerbank</title>
+
+
+  <!-- Latest compiled and minified CSS -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+
+  <!-- Optional theme -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
   <link rel='shortcut icon' type='image/x-icon' href='/favicon.ico' />
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
+
+
+  <!-- Latest compiled and minified JavaScript -->
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 
   <script language="text/javascript">
      function load_js(){
@@ -17,6 +28,8 @@
      }
      load_js();
   </script>
+
+
 </head>
 <body>
 

--- a/upstream/db/migrate/20150609143730_create_dhcp6_fingerprint.rb
+++ b/upstream/db/migrate/20150609143730_create_dhcp6_fingerprint.rb
@@ -1,0 +1,8 @@
+class CreateDhcp6Fingerprint < ActiveRecord::Migration
+  def change
+    create_table :dhcp6_fingerprints do |t|
+      t.string :value, :limit => 1000
+      t.timestamps
+    end
+  end
+end

--- a/upstream/db/migrate/20150609144036_add_dhcp6_fingerprint_to_combinations.rb
+++ b/upstream/db/migrate/20150609144036_add_dhcp6_fingerprint_to_combinations.rb
@@ -1,0 +1,5 @@
+class AddDhcp6FingerprintToCombinations < ActiveRecord::Migration
+  def change
+    add_column :combinations, :dhcp6_fingerprint_id, :integer
+  end
+end

--- a/upstream/db/migrate/20150609144433_set_default_dhcp6_fingerprint.rb
+++ b/upstream/db/migrate/20150609144433_set_default_dhcp6_fingerprint.rb
@@ -1,0 +1,5 @@
+class SetDefaultDhcp6Fingerprint < ActiveRecord::Migration
+  def change
+    Combination.update_all(:dhcp6_fingerprint_id => 0)
+  end
+end

--- a/upstream/db/migrate/20150609181654_add_dhcp6_to_temp_combination.rb
+++ b/upstream/db/migrate/20150609181654_add_dhcp6_to_temp_combination.rb
@@ -1,0 +1,5 @@
+class AddDhcp6ToTempCombination < ActiveRecord::Migration
+  def change
+    add_column :temp_combinations, :dhcp6_fingerprint, :string, :limit => 1000
+  end
+end

--- a/upstream/db/migrate/20150609193832_create_dhcp6_enterprises.rb
+++ b/upstream/db/migrate/20150609193832_create_dhcp6_enterprises.rb
@@ -1,0 +1,10 @@
+class CreateDhcp6Enterprises < ActiveRecord::Migration
+  def change
+    create_table :dhcp6_enterprises do |t|
+      t.string :value, limit: 1000
+
+      t.timestamps
+    end
+    add_column :combinations, :dhcp6_enterprise_id, :integer
+  end
+end

--- a/upstream/db/migrate/20150609195024_add_dhcp6_enterprise_to_temp_combination.rb
+++ b/upstream/db/migrate/20150609195024_add_dhcp6_enterprise_to_temp_combination.rb
@@ -1,0 +1,5 @@
+class AddDhcp6EnterpriseToTempCombination < ActiveRecord::Migration
+  def change
+    add_column :temp_combinations, :dhcp6_enterprise, :string, :limit => 1000
+  end
+end

--- a/upstream/db/migrate/20150609195104_set_default_dhcp6_enterprise.rb
+++ b/upstream/db/migrate/20150609195104_set_default_dhcp6_enterprise.rb
@@ -1,0 +1,5 @@
+class SetDefaultDhcp6Enterprise < ActiveRecord::Migration
+  def change
+    Combination.update_all(:dhcp6_enterprise_id => 0)
+  end
+end

--- a/upstream/db/schema.rb
+++ b/upstream/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150608145948) do
+ActiveRecord::Schema.define(version: 20150609144433) do
 
   create_table "combinations", force: true do |t|
     t.integer  "dhcp_fingerprint_id"
@@ -21,9 +21,10 @@ ActiveRecord::Schema.define(version: 20150608145948) do
     t.integer  "device_id"
     t.string   "version"
     t.integer  "dhcp_vendor_id"
-    t.integer  "score",               default: 0
+    t.integer  "score",                default: 0
     t.integer  "mac_vendor_id"
     t.integer  "submitter_id"
+    t.integer  "dhcp6_fingerprint_id"
   end
 
   add_index "combinations", ["dhcp_fingerprint_id"], name: "combinations_dhcp_fingerprint_id_ix", using: :btree
@@ -49,6 +50,12 @@ ActiveRecord::Schema.define(version: 20150608145948) do
     t.boolean  "inherit"
     t.integer  "submitter_id"
     t.boolean  "approved",     default: true
+  end
+
+  create_table "dhcp6_fingerprints", force: true do |t|
+    t.string   "value",      limit: 1000
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "dhcp_fingerprints", force: true do |t|

--- a/upstream/db/schema.rb
+++ b/upstream/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150609144433) do
+ActiveRecord::Schema.define(version: 20150609181654) do
 
   create_table "combinations", force: true do |t|
     t.integer  "dhcp_fingerprint_id"
@@ -116,12 +116,13 @@ ActiveRecord::Schema.define(version: 20150609144433) do
   end
 
   create_table "temp_combinations", force: true do |t|
-    t.string   "dhcp_fingerprint", limit: 1000
-    t.string   "user_agent",       limit: 1000
-    t.string   "dhcp_vendor",      limit: 1000
+    t.string   "dhcp_fingerprint",  limit: 1000
+    t.string   "user_agent",        limit: 1000
+    t.string   "dhcp_vendor",       limit: 1000
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "mac_vendor",       limit: 1000
+    t.string   "mac_vendor",        limit: 1000
+    t.string   "dhcp6_fingerprint", limit: 1000
   end
 
   create_table "test", force: true do |t|

--- a/upstream/db/schema.rb
+++ b/upstream/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150609181654) do
+ActiveRecord::Schema.define(version: 20150609195104) do
 
   create_table "combinations", force: true do |t|
     t.integer  "dhcp_fingerprint_id"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20150609181654) do
     t.integer  "mac_vendor_id"
     t.integer  "submitter_id"
     t.integer  "dhcp6_fingerprint_id"
+    t.integer  "dhcp6_enterprise_id"
   end
 
   add_index "combinations", ["dhcp_fingerprint_id"], name: "combinations_dhcp_fingerprint_id_ix", using: :btree
@@ -50,6 +51,12 @@ ActiveRecord::Schema.define(version: 20150609181654) do
     t.boolean  "inherit"
     t.integer  "submitter_id"
     t.boolean  "approved",     default: true
+  end
+
+  create_table "dhcp6_enterprises", force: true do |t|
+    t.string   "value",      limit: 1000
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "dhcp6_fingerprints", force: true do |t|
@@ -123,6 +130,7 @@ ActiveRecord::Schema.define(version: 20150609181654) do
     t.datetime "updated_at"
     t.string   "mac_vendor",        limit: 1000
     t.string   "dhcp6_fingerprint", limit: 1000
+    t.string   "dhcp6_enterprise",  limit: 1000
   end
 
   create_table "test", force: true do |t|

--- a/upstream/lib/tasks/fbcache.rake
+++ b/upstream/lib/tasks/fbcache.rake
@@ -34,10 +34,8 @@ namespace :fbcache do |ns|
 
   task benchmark_processing: :environment do
 
-    UserAgent.create(:value => "Mozilla/5.0 (Linux; Android 4.4.2; 0PCV1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36")    
-    user_agent = UserAgent.where(:value => "Mozilla/5.0 (Linux; Android 4.4.2; 0PCV1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36").first
-    Combination.create(:user_agent => user_agent, :dhcp_fingerprint_id => 0, :dhcp_vendor_id => 0)
-    combination = Combination.where(:user_agent => user_agent, :dhcp_fingerprint_id => 0, :dhcp_vendor_id => 0).first
+    user_agent = "Mozilla/5.0 (Linux; Android 4.4.2; 0PCV1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36"
+    combination = Combination.get_or_create(:user_agent => user_agent)
     
     # do it once to bring the cache in mem
     Discoverer.fbcache

--- a/upstream/lib/tasks/import.rake
+++ b/upstream/lib/tasks/import.rake
@@ -392,16 +392,8 @@ namespace :import do |ns|
       elsif state == 'searching_end' && line.empty?
         #puts "Done processing"
         puts "ua : '#{user_agent_value}', fingerprint : '#{fingerprint_value}'"
-        UserAgent.create(:value => user_agent_value)
-        user_agent = UserAgent.where(:value => user_agent_value).first
-        DhcpFingerprint.create(:value => fingerprint_value)
-        dhcp_fingerprint = DhcpFingerprint.where(:value => fingerprint_value).first
-        
-        dhcp_vendor = DhcpVendor.where(:value => '').first
-        mac_vendor = MacVendor.from_mac(nil)
-      
 
-        Combination.create(:user_agent => user_agent, :dhcp_fingerprint => dhcp_fingerprint, :dhcp_vendor => dhcp_vendor, :mac_vendor => mac_vendor)
+        Combination.get_or_create(:user_agent => user_agent_value, :dhcp_fingerprint => dhcp_fingerprint_value)
 
         state = 'searching_ua'
       end
@@ -440,16 +432,8 @@ namespace :import do |ns|
       elsif state == 'searching_end' && line.empty?
         #puts "Done processing"
         puts "ua : #{user_agent_value}, fingerprint : #{fingerprint_value}"
-        UserAgent.create(:value => user_agent_value)
-        user_agent = UserAgent.where(:value => user_agent_value).first
-        DhcpFingerprint.create(:value => fingerprint_value)
-        dhcp_fingerprint = DhcpFingerprint.where(:value => fingerprint_value).first
-        
-        dhcp_vendor = DhcpVendor.where(:value => '').first
-        mac_vendor = MacVendor.from_mac(nil)
-      
 
-        Combination.create(:user_agent => user_agent, :dhcp_fingerprint => dhcp_fingerprint, :dhcp_vendor => dhcp_vendor, :mac_vendor => mac_vendor)
+        Combination.get_or_create(:user_agent => user_agent_value, :dhcp_fingerprint => dhcp_fingerprint_value)
 
         state = 'searching_ua'
       end

--- a/upstream/test/controllers/api/v1/combinations_controller_test.rb
+++ b/upstream/test/controllers/api/v1/combinations_controller_test.rb
@@ -9,6 +9,21 @@ class Api::V1::CombinationsControllerTest < ActionController::TestCase
     @user = users(:normal_user)
   end
 
+  test "should be able to lookup a combination with DHCPv6 information" do
+    combination = combinations(:windows_ipv6)
+    combination.process
+    post :interogate, {:dhcp6_fingerprint => combination.dhcp6_fingerprint.value, :key => @user.key}
+    result = JSON.parse @response.body
+    assert result['id'] == combination.id, "DHCPv6 combination that exists is properly returned by the API"
+
+    post :interogate, {:dhcp6_fingerprint => combination.dhcp6_fingerprint.value, :dhcp_vendor => dhcp_vendors(:microsoft).value, :key => @user.key}
+    result = JSON.parse @response.body
+    puts @response.body
+    assert result['id'] != combination.id, "DHCPv6 combination with new info is not reusing the combination"
+    assert result['device']['id'] == devices(:windows).id, "DHCPv6 combination with new info has yielded the right device"
+
+  end
+
   test "should be able to lookup an existing combination" do
     combination = combinations(:iphone)
     combination.process

--- a/upstream/test/controllers/api/v1/combinations_controller_test.rb
+++ b/upstream/test/controllers/api/v1/combinations_controller_test.rb
@@ -9,7 +9,7 @@ class Api::V1::CombinationsControllerTest < ActionController::TestCase
     @user = users(:normal_user)
   end
 
-  test "should be able to lookup a combination with DHCPv6 information" do
+  test "should be able to lookup a combination with DHCPv6 fingerprint" do
     combination = combinations(:windows_ipv6)
     combination.process
     post :interogate, {:dhcp6_fingerprint => combination.dhcp6_fingerprint.value, :key => @user.key}
@@ -22,6 +22,22 @@ class Api::V1::CombinationsControllerTest < ActionController::TestCase
     assert result['device']['id'] == devices(:windows).id, "DHCPv6 combination with new info has yielded the right device"
 
   end
+
+  test "should be able to lookup a combination with DHCPv6 enterprise" do
+    combination = combinations(:android_ipv6)
+    combination.process
+    post :interogate, {:dhcp6_enterprise => combination.dhcp6_enterprise.value, :key => @user.key}
+    result = JSON.parse @response.body
+    assert result['id'] == combination.id, "DHCPv6 combination that exists is properly returned by the API"
+
+    post :interogate, {:dhcp6_enterprise => combination.dhcp6_enterprise.value, :dhcp_vendor => dhcp_vendors(:microsoft).value, :key => @user.key}
+    result = JSON.parse @response.body
+    assert result['id'] != combination.id, "DHCPv6 combination with new info is not reusing the combination"
+    assert result['device']['id'] == devices(:android).id, "DHCPv6 combination with new info has yielded the right device"
+
+  end
+
+
 
   test "should be able to lookup an existing combination" do
     combination = combinations(:iphone)

--- a/upstream/test/controllers/api/v1/combinations_controller_test.rb
+++ b/upstream/test/controllers/api/v1/combinations_controller_test.rb
@@ -18,7 +18,6 @@ class Api::V1::CombinationsControllerTest < ActionController::TestCase
 
     post :interogate, {:dhcp6_fingerprint => combination.dhcp6_fingerprint.value, :dhcp_vendor => dhcp_vendors(:microsoft).value, :key => @user.key}
     result = JSON.parse @response.body
-    puts @response.body
     assert result['id'] != combination.id, "DHCPv6 combination with new info is not reusing the combination"
     assert result['device']['id'] == devices(:windows).id, "DHCPv6 combination with new info has yielded the right device"
 

--- a/upstream/test/controllers/api/v1/combinations_controller_test.rb
+++ b/upstream/test/controllers/api/v1/combinations_controller_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+require 'json'
+
+class Api::V1::CombinationsControllerTest < ActionController::TestCase
+
+  def setup
+    @admin_user = users(:julsemaan)
+    @blocked_user = users(:blocked_user)
+    @user = users(:normal_user)
+  end
+
+  test "should be able to lookup an existing combination" do
+    combination = combinations(:iphone)
+    combination.process
+    post :interogate, {:user_agent => combination.user_agent.value, :key => @user.key}
+    result = JSON.parse @response.body
+    assert result['id'] == combination.id, "Queried combination is the one that already existed"
+    assert result['device']['id'] == combination.device.id, "Queried combination has the same device"
+  end
+
+  test "should be able to lookup a new combination" do
+    user_agent = "Mozilla/Dinde iPhone"
+    post :interogate, {:user_agent => user_agent, :key => @user.key}
+    result = JSON.parse @response.body
+    assert result['device']['id'] == devices(:iphone).id, "Device is properly discovered"
+  end
+
+  test "shouldn't access the API without a valid key" do
+    # without a key
+    post :interogate, {:user_agent => 'Dinde/5.0'}
+    assert @response.code == "401", "Need a key to access the API"
+
+    # with an invalid key
+    post :interogate, {:user_agent => 'Dinde/5.0', :key => 'this-is-invalid!'}
+    assert @response.code == "401", "Invalid key shouldn't have access to the API"
+  end
+
+  test "normal user shouldn't submit unprocessable data" do
+    value = 'sdfjkhaskdindefnyasdifsdf'
+    post :interogate, {:user_agent => value, :key => @user.key}
+    assert @response.code == "404", "Unknown combination should yield a 404"
+    assert !(Combination.exists?(:user_agent => UserAgent.where(:value => value).first)), "Unknown combination shouldn't be saved if submitted by a normal user"
+  end
+
+  test "api submitter should be able to submit unprocessable data" do
+    value = '1234567890'
+    post :interogate, {:user_agent => value, :key => @admin_user.key}
+    assert @response.code == "404", "Unknown combination should yield a 404"
+    assert (Combination.exists?(:user_agent => UserAgent.where(:value => value).first)), "Unknown combination should be saved if submitted by at least an API submitter"
+  end
+
+  test "blocked user shouldn't access the API" do
+    post :interogate, {:user_agent => "test", :key => @blocked_user.key}
+    assert @response.code == "403", "Blocked user should be given a 403"
+  end
+
+  test "user cannot go above timeframed limit" do
+    @user.update(:timeframed_requests => User.MAX_TIMEFRAMED_REQUESTS+1)
+    post :interogate, {:user_agent => 'test', :key => @user.key}
+    assert @response.code == "403", "User above the timeframed limit should have a 403"
+  end
+end

--- a/upstream/test/fixtures/combinations.yml
+++ b/upstream/test/fixtures/combinations.yml
@@ -4,18 +4,21 @@ iphone:
   user_agent: iphone
   dhcp_fingerprint: empty
   dhcp6_fingerprint: empty
+  dhcp6_enterprise: empty
   dhcp_vendor: empty
 
 android:
   user_agent: android
   dhcp_fingerprint: empty
   dhcp6_fingerprint: empty
+  dhcp6_enterprise: empty
   dhcp_vendor: empty
 
 nintendo:
   user_agent: empty
   dhcp_fingerprint: empty
   dhcp6_fingerprint: empty
+  dhcp6_enterprise: empty
   dhcp_vendor: empty
   mac_vendor: nintendo
 
@@ -23,4 +26,5 @@ windows_ipv6:
   user_agent: empty
   dhcp_fingerprint: empty
   dhcp6_fingerprint: microsoft
+  dhcp6_enterprise: empty
   dhcp_vendor: empty

--- a/upstream/test/fixtures/combinations.yml
+++ b/upstream/test/fixtures/combinations.yml
@@ -28,3 +28,10 @@ windows_ipv6:
   dhcp6_fingerprint: microsoft
   dhcp6_enterprise: empty
   dhcp_vendor: empty
+
+android_ipv6:
+  user_agent: empty
+  dhcp_fingerprint: empty
+  dhcp6_fingerprint: empty
+  dhcp6_enterprise: android
+  dhcp_vendor: empty 

--- a/upstream/test/fixtures/combinations.yml
+++ b/upstream/test/fixtures/combinations.yml
@@ -18,3 +18,9 @@ nintendo:
   dhcp6_fingerprint: empty
   dhcp_vendor: empty
   mac_vendor: nintendo
+
+windows_ipv6:
+  user_agent: empty
+  dhcp_fingerprint: empty
+  dhcp6_fingerprint: microsoft
+  dhcp_vendor: empty

--- a/upstream/test/fixtures/combinations.yml
+++ b/upstream/test/fixtures/combinations.yml
@@ -3,15 +3,18 @@
 iphone:
   user_agent: iphone
   dhcp_fingerprint: empty
+  dhcp6_fingerprint: empty
   dhcp_vendor: empty
 
 android:
   user_agent: android
   dhcp_fingerprint: empty
+  dhcp6_fingerprint: empty
   dhcp_vendor: empty
 
 nintendo:
   user_agent: empty
   dhcp_fingerprint: empty
+  dhcp6_fingerprint: empty
   dhcp_vendor: empty
   mac_vendor: nintendo

--- a/upstream/test/fixtures/devices.yml
+++ b/upstream/test/fixtures/devices.yml
@@ -14,3 +14,8 @@ nintendo:
   name: 'Nintendo Pii'
   mobile: false
   tablet: false
+
+windows:
+  name: 'Windows computer'
+  mobile: false
+  tablet: false

--- a/upstream/test/fixtures/dhcp6_enterprises.yml
+++ b/upstream/test/fixtures/dhcp6_enterprises.yml
@@ -2,3 +2,6 @@
 
 empty:
   value: ''
+
+android:
+  value: 'Google mobile OS'

--- a/upstream/test/fixtures/dhcp6_enterprises.yml
+++ b/upstream/test/fixtures/dhcp6_enterprises.yml
@@ -1,0 +1,4 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+empty:
+  value: ''

--- a/upstream/test/fixtures/dhcp6_fingerprints.yml
+++ b/upstream/test/fixtures/dhcp6_fingerprints.yml
@@ -2,3 +2,6 @@
 
 empty:
   value: ''
+
+microsoft:
+  value: '24,23,17,39' 

--- a/upstream/test/fixtures/dhcp6_fingerprints.yml
+++ b/upstream/test/fixtures/dhcp6_fingerprints.yml
@@ -1,8 +1,4 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-nintendo:
-  name: 'Nintendo Inc.'
-
-zammit:
-  name: 'Zammit corp'
-  mac: '123456'
+empty:
+  value: ''

--- a/upstream/test/fixtures/dhcp_vendors.yml
+++ b/upstream/test/fixtures/dhcp_vendors.yml
@@ -2,3 +2,6 @@
 
 empty:
   value: ''
+
+microsoft:
+  value: 'MSFT 5.0'

--- a/upstream/test/fixtures/discoverers.yml
+++ b/upstream/test/fixtures/discoverers.yml
@@ -17,3 +17,6 @@ iphone_version:
   device: iphone
   version: "REPLACE( PREG_CAPTURE('/CPU .* ([0-9_]+) like Mac OS X/', user_agents.value, 1), '_', '.')"
 
+windows_ipv6:
+  priority: 50
+  device: windows

--- a/upstream/test/fixtures/discoverers.yml
+++ b/upstream/test/fixtures/discoverers.yml
@@ -20,3 +20,7 @@ iphone_version:
 windows_ipv6:
   priority: 50
   device: windows
+
+android_ipv6:
+  priority: 50
+  device: android

--- a/upstream/test/fixtures/rules.yml
+++ b/upstream/test/fixtures/rules.yml
@@ -16,3 +16,6 @@ iphone_version:
   value: "user_agents.value regexp 'CPU .* ([0-9_]+) like Mac OS X'"
   version_discoverer: iphone_version
 
+windows_ipv6:
+  value: "dhcp6_fingerprints.value = '24,23,17,39'"
+  device_discoverer: windows_ipv6

--- a/upstream/test/fixtures/rules.yml
+++ b/upstream/test/fixtures/rules.yml
@@ -19,3 +19,7 @@ iphone_version:
 windows_ipv6:
   value: "dhcp6_fingerprints.value = '24,23,17,39'"
   device_discoverer: windows_ipv6
+
+android_ipv6:
+  value: "dhcp6_enterprises.value LIKE '%Google%'"
+  device_discoverer: android_ipv6

--- a/upstream/test/fixtures/users.yml
+++ b/upstream/test/fixtures/users.yml
@@ -6,3 +6,16 @@ julsemaan:
   email: 'TBD'
   level: 10 
   key: 'seeded-key'
+
+normal_user:
+  name: 'Ludovic Zammit'
+  email: 'ludovic@zamm.it'
+  level: 0
+  key: 'pain-dinde-moutarde'
+
+blocked_user:
+  name: 'Mr. Blocked'
+  email: 'abuser@example.com'
+  level: 0
+  key: 'i-luv-ddos'
+  blocked: 1

--- a/upstream/test/models/combination_test.rb
+++ b/upstream/test/models/combination_test.rb
@@ -1,6 +1,22 @@
 require 'test_helper'
 
 class CombinationTest < ActiveSupport::TestCase
+
+  test 'create a combination with default values' do
+    combination = Combination.get_or_create(:dhcp_fingerprint => "1,2,3,4,5", :user_agent => "Mozilla/Dinde")
+    assert combination.dhcp_fingerprint.value == "1,2,3,4,5", "DHCP fingerprint was properly created"
+    assert combination.user_agent.value == "Mozilla/Dinde", "User agent was properly created"
+    assert combination.dhcp_vendor == dhcp_vendors(:empty), "DHCP vendor is set to empty"
+    assert combination.mac_vendor.nil?, "MAC vendor is set to NULL"
+    assert combination.dhcp6_fingerprint == dhcp6_fingerprints(:empty), "DHCP6 fingerprint vendor is set to empty"
+
+    combination = Combination.get_or_create(:mac => '1234567890ab', :dhcp6_fingerprint => '5,4,3,2,1', :dhcp_vendor => 'Microhard')
+    assert combination.mac_vendor == mac_vendors(:zammit), "MAC vendor is properly detected"
+    assert combination.dhcp6_fingerprint.value == "5,4,3,2,1", "DHCP6 fingerprint was properly created"
+    assert combination.dhcp_vendor.value == 'Microhard', "DHCP vendor was properly created"
+  end
+
+
   test 'fixtures are there' do
     assert combinations(:iphone).user_agent.value == 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) GSA/5.2.43972 Mobile/11D257 Safari/9537.53'
   end
@@ -61,12 +77,12 @@ class CombinationTest < ActiveSupport::TestCase
     FingerbankCache.delete("model_regex_assoc")
     # we create a new combination with a new user agent
     user_agent = UserAgent.create!(:value => 'Mozilla/5.0 (Linux; Android 4.1.2; SGH-T599N Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.86 Mobile Safari/537.36')
-    combination = Combination.create!(:user_agent => user_agent, :dhcp_vendor => dhcp_vendors(:empty), :dhcp_fingerprint => dhcp_fingerprints(:empty))
+    combination = Combination.get_or_create(:user_agent => user_agent, :dhcp_vendor => dhcp_vendors(:empty), :dhcp_fingerprint => dhcp_fingerprints(:empty))
     assert combination.process(:with_version => true, :save => true), "New android combination can be processed"
     assert combination.processed_method == "find_matching_discoverers_tmp_table"
 
     mac_vendor = mac_vendors(:nintendo)
-    combination = Combination.create!(:user_agent => user_agent, :dhcp_vendor => dhcp_vendors(:empty), :dhcp_fingerprint => dhcp_fingerprints(:empty), :mac_vendor => mac_vendor)
+    combination = Combination.get_or_create(:user_agent => user_agent, :dhcp_vendor => dhcp_vendors(:empty), :dhcp_fingerprint => dhcp_fingerprints(:empty), :mac_vendor => mac_vendor)
     assert combination.process(:with_version => true, :save => true), "New android combination can be processed"
     assert combination.processed_method == "find_matching_discoverers_tmp_table"
     
@@ -76,7 +92,7 @@ class CombinationTest < ActiveSupport::TestCase
     Discoverer.fbcache
     # we create a new combination with a new user agent
     user_agent = UserAgent.create!(:value => 'Mozilla/5.0 (Linux; Android 4.1.2; SGH-T599N Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.86 Mobile Safari/537.36')
-    combination = Combination.create!(:user_agent => user_agent, :dhcp_vendor => dhcp_vendors(:empty), :dhcp_fingerprint => dhcp_fingerprints(:empty))
+    combination = Combination.get_or_create(:user_agent => user_agent, :dhcp_vendor => dhcp_vendors(:empty), :dhcp_fingerprint => dhcp_fingerprints(:empty))
     assert combination.process(:with_version => true, :save => true), "New android combination can be processed"
     assert combination.processed_method == "find_matching_discoverers_local"
     

--- a/upstream/test/models/dhcp6_enterprise_test.rb
+++ b/upstream/test/models/dhcp6_enterprise_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Dhcp6EnterpriseTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Not ready, missing view of DHCPv6 attributes in the combinations listing

# Description
Adds full support (discovery and collection) of DHCPv6 attributes (DHCPv6 fingerprint and DHCPv6 enterprise ID)

This also does cleanup work in the combination creation (for the default values)

# Impacts
Will need to update all existing combinations
Adds more discovery options
Negative impacts should be limited as there are unit tests for the models and API controller tests