### PR TITLE
Move to use JSON::MaybeXS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,6 +17,7 @@ Depends: ${misc:Depends},
  libconfig-general-perl,libreadonly-xs-perl, 
  liblog-log4perl-perl (>=1.43),libcatalyst-action-rest-perl,
  libdbd-sqlite3-perl, liblwp-protocol-https-perl, sqlite3,
+ libjson-maybexs-perl,
 Description: fingerbank
  No! Fingerbank is not an organ bank for nice fingers ;)
  It is a database for device fingerprinting based on different properties

--- a/remote/perl/lib/fingerbank/DB.pm
+++ b/remote/perl/lib/fingerbank/DB.pm
@@ -14,7 +14,7 @@ use Moose;
 use namespace::autoclean;
 
 use File::Copy qw(copy move);
-use JSON;
+use JSON::MaybeXS;
 use LWP::UserAgent;
 use POSIX qw(strftime);
 

--- a/remote/perl/lib/fingerbank/Query.pm
+++ b/remote/perl/lib/fingerbank/Query.pm
@@ -3,7 +3,7 @@ package fingerbank::Query;
 use Moose;
 use namespace::autoclean;
 
-use JSON;
+use JSON::MaybeXS;
 use LWP::UserAgent;
 use Module::Load;
 use POSIX;

--- a/remote/perl/lib/fingerbank/Source/API.pm
+++ b/remote/perl/lib/fingerbank/Source/API.pm
@@ -13,7 +13,7 @@ Source for interrogating the upstream Fingerbank API
 use Moose;
 extends 'fingerbank::Base::Source';
 
-use JSON;
+use JSON::MaybeXS;
 
 use fingerbank::Config;
 use fingerbank::Constant qw($TRUE);

--- a/remote/perl/lib/fingerbank/Source/LocalDB.pm
+++ b/remote/perl/lib/fingerbank/Source/LocalDB.pm
@@ -15,7 +15,7 @@ extends 'fingerbank::Base::Source';
 
 use namespace::autoclean;
 
-use JSON;
+use JSON::MaybeXS;
 use LWP::UserAgent;
 use Module::Load;
 use POSIX;

--- a/remote/perl/t/endpoint.t
+++ b/remote/perl/t/endpoint.t
@@ -59,7 +59,7 @@ my $json_result = <<"RESULT";
 }
 RESULT
 
-use JSON;
+use JSON::MaybeXS;
 my $result = decode_json($json_result);
 
 $endpoint = fingerbank::Model::Endpoint->fromResult($result);

--- a/rhel/fingerbank.spec
+++ b/rhel/fingerbank.spec
@@ -31,6 +31,7 @@ Requires:   perl(Log::Log4perl)
 Requires:   perl(Catalyst::Model::DBIC::Schema)
 Requires:   perl(Catalyst::Action::REST)
 Requires:   perl(DBD::SQLite)
+Requires:   perl(JSON::MaybeXS)
 Requires:   perl(LWP::Protocol::https)
 Requires:   perl(MooseX::NonMoose)
 


### PR DESCRIPTION
Move to use JSON::MaybeXS

Description
-----------
Since JSON::XS has some bugs that are not fixed.
Newer perl modules are moving to Cpanel::JSON::XS.
The recommended JSON package is JSON::MaybeXS.
Which will load JSON encoder/decoder modules in the following order.
Cpanel::JSON::XS, JSON::XS, then JSON::PP

Impacts
-------
Packaging

NEWS file entries
-------

Enhancements
++++++++++++
* Move to Cpanel::JSON::XS

Delete branch after merge
-------------------------
NO